### PR TITLE
feat(oauth) 쿠키에 access/refresh token

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -19,13 +19,13 @@ export class AuthController {
   getHello(): any {
     throw new Error('Method not implemented.');
   }
-  constructor(private readonly authservice: AuthService) {}
+  constructor(private readonly authservice: AuthService) { }
 
   // @UseGuards(GoogleAuthGuard)
   //구글 로그인 요청
   @Get('google')
   @UseGuards(AuthGuard('google'))
-  async googleAuth(@Req() req) {}
+  async googleAuth(@Req() req) { }
 
   // @UseGuards(GoogleAuthGuard)
   //구글 로그인 완료
@@ -36,9 +36,13 @@ export class AuthController {
     @Res({ passthrough: true }) response: any,
   ) {
     await this.authservice.googleLogin(req);
-    const tokens = await this.authservice.getJwtTokens(req.user.email);
-
-    response.json(tokens);
+    const { access_token, refresh_token } = await this.authservice.getJwtTokens(
+      req.user.email,
+    );
+    response
+      .cookie('access_token', access_token)
+      .cookie('refresh_token', refresh_token)
+      .redirect(HttpStatus.PERMANENT_REDIRECT, process.env.CLIENT_URL);
   }
 
   /**
@@ -46,7 +50,9 @@ export class AuthController {
    */
   @Get('kakao')
   @UseGuards(AuthGuard('kakao'))
-  async kakaoAuth(@Req() req) {}
+  async kakaoAuth(@Req() req) {
+    Logger.log('kakaoAuth');
+  }
 
   /**
    * 카카오 로그인 완료
@@ -55,11 +61,23 @@ export class AuthController {
    */
   @Get('kakao/redirect')
   @UseGuards(AuthGuard('kakao'))
-  async kakaoAuthRedirect(@Req() req, @Res() response: any) {
-    await this.authservice.kakaoLogin(req);
-    const tokens = await this.authservice.getJwtTokens(req.user.email);
+  async kakaoAuthRedirect(@Req() req, @Res() response: Response) {
+    Logger.log('kakaoAuthRedirect');
 
-    response.json(tokens);
+    await this.authservice.kakaoLogin(req);
+    const { access_token, refresh_token } = await this.authservice.getJwtTokens(
+      req.user.email,
+    );
+    response
+      .cookie('access_token', access_token, {
+        expires: new Date(Date.now() + 1000 * 60),
+        httpOnly: true,
+      })
+      .cookie('refresh_token', refresh_token, {
+        expires: new Date(Date.now() + 1000 * 60),
+        httpOnly: true,
+      })
+      .redirect(HttpStatus.PERMANENT_REDIRECT, process.env.CLIENT_URL);
   }
 
   /**
@@ -67,7 +85,7 @@ export class AuthController {
    */
   @Get('naver')
   @UseGuards(AuthGuard('naver'))
-  async naverAuth(@Req() req) {}
+  async naverAuth(@Req() req) { }
 
   /**
    * 네이버 로그인 완료
@@ -76,11 +94,21 @@ export class AuthController {
    */
   @Get('naver/redirect')
   @UseGuards(AuthGuard('naver'))
-  async naverAuthRedirect(@Req() req, @Res() response: any) {
+  async naverAuthRedirect(@Req() req, @Res() response: Response) {
     await this.authservice.naverLogin(req);
-    const tokens = await this.authservice.getJwtTokens(req.user.email);
-
-    response.json(tokens);
+    const { access_token, refresh_token } = await this.authservice.getJwtTokens(
+      req.user.email,
+    );
+    response
+      .cookie('access_token', access_token, {
+        expires: new Date(Date.now() + 1000 * 60),
+        httpOnly: true,
+      })
+      .cookie('refresh_token', refresh_token, {
+        expires: new Date(Date.now() + 1000 * 60),
+        httpOnly: true,
+      })
+      .redirect(HttpStatus.PERMANENT_REDIRECT, process.env.CLIENT_URL);
   }
 
   @Get('token')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -42,13 +42,14 @@ export class AuthController {
     response
       .cookie('access_token', access_token, {
         expires: new Date(Date.now() + 1000 * 60),
-        httpOnly: true,
       })
       .cookie('refresh_token', refresh_token, {
         expires: new Date(Date.now() + 1000 * 60),
-        httpOnly: true,
       })
-      .redirect(HttpStatus.PERMANENT_REDIRECT, process.env.CLIENT_URL);
+      .redirect(
+        HttpStatus.PERMANENT_REDIRECT,
+        process.env.CLIENT_URL + '/token',
+      );
   }
 
   /**
@@ -81,9 +82,11 @@ export class AuthController {
       })
       .cookie('refresh_token', refresh_token, {
         expires: new Date(Date.now() + 1000 * 60),
-        httpOnly: true,
       })
-      .redirect(HttpStatus.PERMANENT_REDIRECT, process.env.CLIENT_URL);
+      .redirect(
+        HttpStatus.PERMANENT_REDIRECT,
+        process.env.CLIENT_URL + '/token',
+      );
   }
 
   /**
@@ -108,13 +111,14 @@ export class AuthController {
     response
       .cookie('access_token', access_token, {
         expires: new Date(Date.now() + 1000 * 60),
-        httpOnly: true,
       })
       .cookie('refresh_token', refresh_token, {
         expires: new Date(Date.now() + 1000 * 60),
-        httpOnly: true,
       })
-      .redirect(HttpStatus.PERMANENT_REDIRECT, process.env.CLIENT_URL);
+      .redirect(
+        HttpStatus.PERMANENT_REDIRECT,
+        process.env.CLIENT_URL + '/token',
+      );
   }
 
   @Get('token')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -38,10 +38,7 @@ export class AuthController {
     await this.authservice.googleLogin(req);
     const tokens = await this.authservice.getJwtTokens(req.user.email);
 
-    response.redirect(
-      HttpStatus.PERMANENT_REDIRECT,
-      `http://localhost:3000/token?access_token=${tokens.access_token}&refresh_token=${tokens.refresh_token}`,
-    );
+    response.json(tokens);
   }
 
   /**
@@ -62,10 +59,7 @@ export class AuthController {
     await this.authservice.kakaoLogin(req);
     const tokens = await this.authservice.getJwtTokens(req.user.email);
 
-    response.redirect(
-      HttpStatus.PERMANENT_REDIRECT,
-      `http://localhost:3000/token?access_token=${tokens.access_token}&refresh_token=${tokens.refresh_token}`,
-    );
+    response.json(tokens);
   }
 
   /**
@@ -85,10 +79,8 @@ export class AuthController {
   async naverAuthRedirect(@Req() req, @Res() response: any) {
     await this.authservice.naverLogin(req);
     const tokens = await this.authservice.getJwtTokens(req.user.email);
-    response.redirect(
-      HttpStatus.PERMANENT_REDIRECT,
-      `http://localhost:3000/token?access_token=${tokens.access_token}&refresh_token=${tokens.refresh_token}`,
-    );
+
+    response.json(tokens);
   }
 
   @Get('token')

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -33,23 +33,13 @@ export class AuthController {
   @UseGuards(AuthGuard('google'))
   async googleAuthRedirect(
     @Req() req,
-    @Res({ passthrough: true }) response: any,
+    @Res({ passthrough: true }) response: Response,
   ) {
     await this.authservice.googleLogin(req);
     const { access_token, refresh_token } = await this.authservice.getJwtTokens(
       req.user.email,
     );
-    response
-      .cookie('access_token', access_token, {
-        expires: new Date(Date.now() + 1000 * 60),
-      })
-      .cookie('refresh_token', refresh_token, {
-        expires: new Date(Date.now() + 1000 * 60),
-      })
-      .redirect(
-        HttpStatus.PERMANENT_REDIRECT,
-        process.env.CLIENT_URL + '/token',
-      );
+    this.responseWithCookieAndRedirect(response, access_token, refresh_token);
   }
 
   /**
@@ -75,18 +65,7 @@ export class AuthController {
     const { access_token, refresh_token } = await this.authservice.getJwtTokens(
       req.user.email,
     );
-    response
-      .cookie('access_token', access_token, {
-        expires: new Date(Date.now() + 1000 * 60),
-        httpOnly: true,
-      })
-      .cookie('refresh_token', refresh_token, {
-        expires: new Date(Date.now() + 1000 * 60),
-      })
-      .redirect(
-        HttpStatus.PERMANENT_REDIRECT,
-        process.env.CLIENT_URL + '/token',
-      );
+    this.responseWithCookieAndRedirect(response, access_token, refresh_token);
   }
 
   /**
@@ -108,17 +87,7 @@ export class AuthController {
     const { access_token, refresh_token } = await this.authservice.getJwtTokens(
       req.user.email,
     );
-    response
-      .cookie('access_token', access_token, {
-        expires: new Date(Date.now() + 1000 * 60),
-      })
-      .cookie('refresh_token', refresh_token, {
-        expires: new Date(Date.now() + 1000 * 60),
-      })
-      .redirect(
-        HttpStatus.PERMANENT_REDIRECT,
-        process.env.CLIENT_URL + '/token',
-      );
+    this.responseWithCookieAndRedirect(response, access_token, refresh_token);
   }
 
   @Get('token')
@@ -134,5 +103,26 @@ export class AuthController {
         req.body.refresh_token,
       );
     response.json({ access_token });
+  }
+
+  private responseWithCookieAndRedirect(
+    response: Response,
+    access_token: string,
+    refresh_token: string,
+  ) {
+    response
+      .cookie('access_token', access_token, {
+        expires: new Date(Date.now() + 1000 * 60),
+        sameSite: 'lax',
+        // secure: true, /// TODO: https 적용시 주석 해제
+      })
+      .cookie('refresh_token', refresh_token, {
+        sameSite: 'lax',
+        // secure: true, /// TODO: https 적용시 주석 해제
+      })
+      .redirect(
+        HttpStatus.PERMANENT_REDIRECT,
+        process.env.CLIENT_URL + '/token',
+      );
   }
 }

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -40,8 +40,14 @@ export class AuthController {
       req.user.email,
     );
     response
-      .cookie('access_token', access_token)
-      .cookie('refresh_token', refresh_token)
+      .cookie('access_token', access_token, {
+        expires: new Date(Date.now() + 1000 * 60),
+        httpOnly: true,
+      })
+      .cookie('refresh_token', refresh_token, {
+        expires: new Date(Date.now() + 1000 * 60),
+        httpOnly: true,
+      })
       .redirect(HttpStatus.PERMANENT_REDIRECT, process.env.CLIENT_URL);
   }
 

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -19,13 +19,13 @@ export class AuthController {
   getHello(): any {
     throw new Error('Method not implemented.');
   }
-  constructor(private readonly authservice: AuthService) { }
+  constructor(private readonly authservice: AuthService) {}
 
   // @UseGuards(GoogleAuthGuard)
   //구글 로그인 요청
   @Get('google')
   @UseGuards(AuthGuard('google'))
-  async googleAuth(@Req() req) { }
+  async googleAuth(@Req() req) {}
 
   // @UseGuards(GoogleAuthGuard)
   //구글 로그인 완료
@@ -85,7 +85,7 @@ export class AuthController {
    */
   @Get('naver')
   @UseGuards(AuthGuard('naver'))
-  async naverAuth(@Req() req) { }
+  async naverAuth(@Req() req) {}
 
   /**
    * 네이버 로그인 완료


### PR DESCRIPTION
## AI summary

This pull request updates the OAuth login functionality in the AuthController. The changes include reverting the response from redirect to JSON, sending the access and refresh tokens as cookies.

## Note

- `.env` 파일에 CLIENT_URL을 추가하셔야 의도된 동작을 수행할 수 있습니다.
- set cookie 요청의 옵션으로 유효기간을 일부로 **1분**으로 설정하였고 `http-only` 옵션을 넣었습니다. 즉, 클라이언트는 쿠키를 받아 로컬 스토리지에 저장하는 식으로 진행해야 합니다.