### PR TITLE
Add createdDt column to User entity

### DIFF
--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -24,8 +24,8 @@ export class User {
   })
   provider: string;
 
-  // @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
-  // createdDt: Date;
+  @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+  createdDt: Date;
 
   // @Column({ type: 'varchar', length: 15 })
   // username: string;

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -29,7 +29,7 @@ export class UserService {
     user.profileImage = createUserDto.profileImage;
     user.provider = createUserDto.provider;
     user.email = createUserDto.email;
-    // user.createdDt = new Date(Date.now());
+    user.createdDt = new Date(Date.now());
     return this.userRepository.save(user);
   }
 


### PR DESCRIPTION
이 풀 리퀘스트는 사용자 레코드의 생성 날짜를 추적하기 위해 `사용자` 엔티티에 `createdDt`라는 새 열을 추가합니다.이 열의 유형은 `타임스탬프`이며 기본값은 현재 타임스탬프입니다. 이 변경으로 사용자 기록을 더 잘 추적하고 관리할 수 있습니다.
