### PR TITLE
Add sync host interval

### DIFF
--- a/src/session/session.gateway.ts
+++ b/src/session/session.gateway.ts
@@ -311,6 +311,7 @@ export class SessionGateway
       clientEntity.nickname = nickname;
       this.roomidToPlayerSet.get(Number(room_id)).add(uuId.toString());
       client.join(room_id.toString());
+      client.emit('ready', { result: true, message: '게임에 참가하였습니다.' });
     }
 
     Logger.log("게임 참가자: " + nickname + " 룸 번호: " + room_id + " 총 참가 인원: " +
@@ -418,9 +419,21 @@ export class SessionGateway
     this.clientsLastActivity.delete(uuId);
   }
 
+  syncGameRoomInfo(){
+    this.catchGameRoom.forEach((value, key) => {
+      const hostuuid = this.roomIdToHostId.get(key);
+      const host = this.uuidToclientEntity.get(hostuuid).clientSocket;
+      host.emit('player_list_add', { player_cnt: value.current_user_num, nickname: null });
+    })
+  }
+
   onModuleInit() {
     setInterval(() => {
+      this.syncGameRoomInfo();
+    }, 3000);
+
+    setInterval(() => {
       this.checkInactiveClients();
-    }, 2000);
+    }, 4000);
   }
 }


### PR DESCRIPTION
이 pull request는 SessionGateway 클래스에 sync 호스트 간격을 추가합니다. sync 호스트 간격은 클라이언트 간의 게임 룸 정보를 동기화하는 데 사용됩니다. 다음과 같은 변경 사항이 포함되어 있습니다:

syncGameRoomInfo()라는 새로운 메서드를 추가하여 게임 룸 정보를 동기화합니다.

onModuleInit() 메서드를 수정하여 일정 간격으로 syncGameRoomInfo()를 호출합니다.

sync 간격을 2000ms에서 4000ms로 업데이트했습니다.

이 개선으로 게임 룸 동기화 프로세스의 전반적인 성능과 신뢰성이 향상됩니다.