### PR TITLE
feat(normalize): remove 'Bearer ' and quotation marks from token

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -8,6 +8,7 @@ import { HttpErrorByCode } from '@nestjs/common/utils/http-error-by-code.util';
 import { JwtService } from '@nestjs/jwt';
 import { CreateUserDto } from 'src/user/dto/create-user.dto';
 import { UserService } from 'src/user/user.service';
+import { normalizeToken } from './normalize-token';
 
 @Injectable()
 export class AuthService {
@@ -121,25 +122,32 @@ export class AuthService {
 
   async getJwtAccessTokenFromRefreshToken(refreshToken: string) {
     let verify: object | Buffer;
-    refreshToken = refreshToken.replace('Bearer ', '');
+    refreshToken = normalizeToken(refreshToken);
     try {
       verify = this.jwtService.verify(refreshToken, {
         secret: process.env.JWT_REFRESH_TOKEN_SECRET,
       });
-      Logger.debug(JSON.stringify(verify), 'getJwtAccessTokenFromRefreshToken');
+      Logger.debug(
+        `verify: ${JSON.stringify(verify)}`,
+        'getJwtAccessTokenFromRefreshToken',
+      );
     } catch (e) {
       switch (e.message) {
         // 토큰에 대한 오류를 판단합니다.
         case 'INVALID_TOKEN':
         case 'TOKEN_IS_ARRAY':
-        case 'NO_USER':
+        case 'NO_USER': {
           throw new HttpException('유효하지 않은 토큰입니다.', 401);
+        }
 
-        case 'EXPIRED_TOKEN':
+        case 'EXPIRED_TOKEN': {
           throw new HttpException('토큰이 만료되었습니다.', 410);
+        }
 
-        default:
+        default: {
+          Logger.error(`UNDEFINED_ERROR`, `getJwtAccessTokenFromRefreshToken`);
           throw new HttpException('서버 오류입니다.', 500);
+        }
       }
     }
     const userInfo = await this.userService.findUser(
@@ -148,13 +156,8 @@ export class AuthService {
     );
     const payload = { email: userInfo.email, provider: userInfo.provider };
 
-    const token =
-      'Bearer ' +
-      this.jwtService.sign(payload, {
-        secret: process.env.JWT_ACCESS_TOKEN_SECRET,
-        expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME,
-      });
-    return token;
+    const access_token = this.getJwtAccessToken(payload);
+    return 'Bearer ' + access_token;
   }
 
   // async verifyJwtAccessToken(accessToken: string) {

--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -8,6 +8,7 @@ import {
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { JwtService } from '@nestjs/jwt';
+import { normalizeToken } from './normalize-token';
 
 @Injectable()
 export class JwtAuthGuard extends AuthGuard('jwt') {
@@ -23,7 +24,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       throw new HttpException('Token 전송 안됨', HttpStatus.UNAUTHORIZED);
     }
 
-    const token = authorization.replace(/["']/g, '').replace('Bearer ', ''); // Remove quotation marks and 'Bearer ' prefix
+    const token = normalizeToken(authorization);
 
     Logger.debug(`token = ${token}`, 'JwtAuthGuard');
 
@@ -39,20 +40,24 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
       payload = this.jwtService.verify(token, {
         secret: secretKey,
       });
+      Logger.debug(`verify 성공! ${JSON.stringify(payload)}`, 'JwtAuthGuard');
       return payload;
     } catch (e) {
+      Logger.error(`verify 실패! ${JSON.stringify(e)}`, 'JwtAuthGuard');
       switch (e.name) {
         // 토큰에 대한 오류를 판단합니다.
         case 'JsonWebTokenError': {
-          Logger.error(`payload: ${JSON.stringify(payload)}`, `JwtAuthGuard`);
           throw new HttpException('유효하지 않은 토큰입니다.', 401);
         }
 
-        case 'TokenExpiredError':
+        case 'TokenExpiredError': {
           throw new HttpException('토큰이 만료되었습니다.', 410);
+        }
 
-        default:
+        default: {
+          Logger.error(`서버 오류입니다. (${e})`, `JwtAuthGuard`);
           throw new HttpException('서버 오류입니다.', 500);
+        }
       }
     }
   }

--- a/src/auth/normalize-token.ts
+++ b/src/auth/normalize-token.ts
@@ -1,0 +1,6 @@
+import { Logger } from '@nestjs/common';
+
+export const normalizeToken = (token: string) => {
+  return token.replace(/["']/g, '').replace('Bearer ', '');
+};
+

--- a/src/session/session.guard.ts
+++ b/src/session/session.guard.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { AuthService } from 'src/auth/auth.service';
+import { normalizeToken } from 'src/auth/normalize-token';
 import { UserService } from 'src/user/user.service';
 
 @Injectable()
@@ -21,7 +22,7 @@ export class SessionGuard implements CanActivate {
 
     let accessToken = payload.access_token;
     let tokenPayload = null;
-    accessToken = accessToken.replace('Bearer ', '');
+    accessToken = normalizeToken(accessToken);
     try {
       //엑서스 토큰 검증
       tokenPayload = this.jwtService.verify(accessToken, {


### PR DESCRIPTION
이 풀 리퀘스트는 AuthService 및 JwtAuthGuard 클래스의 토큰에서 'Bearer ' 접두사와 따옴표를 제거합니다. 또한 이 변환을 처리하기 위해 normalizeToken 함수를 도입합니다. 이 변경으로 토큰 처리가 개선되고 코드베이스 전체에서 일관성이 보장됩니다.