### PR TITLE
플레이어 오답 여부 전송/감정표현/호스트 정답갱신 방지

### DIFF
--- a/src/session/session.gateway.ts
+++ b/src/session/session.gateway.ts
@@ -584,6 +584,15 @@ export class SessionGateway
         const { room_id, ans } = payload;
         const room = this.catchGameRoom.get(Number(room_id));
 
+        if (room.status !== 0) {
+            console.log('게임이 이미 시작되었습니다.');
+            client.emit('set_catch_answer', {
+                result: false,
+                message: '게임이 이미 시작되었습니다.',
+            });
+            return;
+        }
+
         room.correctAnswer = ans;
         Logger.log(room_id + '번방 정답 설정: ' + ans);
         host.emit('set_catch_answer', { result: true, answer: ans });

--- a/src/session/session.gateway.ts
+++ b/src/session/session.gateway.ts
@@ -439,10 +439,8 @@ export class SessionGateway
                 nickname: clientEntity.nickname,
             });
             client.emit('incorrect', {
-                    result: true,
-                    incorrectAnswer: ans,
-                    nickname: clientEntity.nickname,
-                });
+                    message: '땡!',
+            });
 
         }
     }
@@ -568,7 +566,7 @@ export class SessionGateway
         const hostuuId = this.roomIdToHostId.get(Number(payload.room_id));
         if (hostuuId === undefined) {
             client.emit('set_catch_answer', {
-                result: false,
+                type: 'not_found_room',
                 message: '방이 존재하지 않습니다.',
             });
             return;
@@ -587,16 +585,17 @@ export class SessionGateway
         if (room.status !== 0) {
             console.log('게임이 이미 시작되었습니다.');
             client.emit('set_catch_answer', {
-                result: false,
+                type: 'already_started',
                 message: '게임이 이미 시작되었습니다.',
             });
+            console.log('정답:', room.correctAnswer)
             return;
         }
 
         room.correctAnswer = ans;
         Logger.log(room_id + '번방 정답 설정: ' + ans);
-        host.emit('set_catch_answer', { result: true, answer: ans });
-        client.emit('set_catch_answer', { result: true, answer: ans });
+        host.emit('set_catch_answer', { type: 'answer_success', answer: ans });
+        client.emit('set_catch_answer', { type: 'answer_success', answer: ans });
     }
 
     dellConnectionInfo(uuId: string) {


### PR DESCRIPTION
- `throw_catch_answer`에서 오답 시 해당 플레이어에게 오답 여부 전송:  `incorrect`이벤트로 emit
- 감정표현 이벤트 `express_emotion` 추가
- `set_catch_answer`에서 게임 시작 후 호스트가 정답을 갱신하지 못하도록 조치
   -> emit attribute를 boolean으로 T/F 두가지만 가능했던 'result'에서 'type'으로 변경