### PR TITLE
Number casting on all env vars

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -106,7 +106,7 @@ export class AuthService {
         const payload = { email: userInfo.email, provider: userInfo.provider };
         const token = this.jwtService.sign(payload, {
             secret: process.env.JWT_ACCESS_TOKEN_SECRET,
-            expiresIn: process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME,
+            expiresIn: +process.env.JWT_ACCESS_TOKEN_EXPIRATION_TIME,
         });
         return token;
     }
@@ -115,7 +115,7 @@ export class AuthService {
         const payload = { email: userInfo.email, provider: userInfo.provider };
         const token = this.jwtService.sign(payload, {
             secret: process.env.JWT_REFRESH_TOKEN_SECRET,
-            expiresIn: process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME,
+            expiresIn: +process.env.JWT_REFRESH_TOKEN_EXPIRATION_TIME,
         });
         return token;
     }

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,6 @@ async function bootstrap() {
     if (!process.env.LISTEN_PORT) {
         throw new Error('LISTEN_PORT is not defined');
     }
-    await app.listen(process.env.LISTEN_PORT);
+    await app.listen(+process.env.LISTEN_PORT);
 }
 bootstrap();


### PR DESCRIPTION
이 풀 리퀘스트는 코드에서 환경 변수를 사용할 때 숫자로 캐스팅되지 않던 문제를 해결합니다. 숫자 캐스팅을 추가하여 변수가 숫자로 올바르게 해석되도록 합니다. 이를 통해 코드의 안정성과 정확성이 향상됩니다.
