### PR TITLE
Fix dependency exports in modules

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -14,5 +14,6 @@ import { JwtAuthGuard } from './jwt-auth.guard';
     imports: [TypeOrmModule.forFeature([User]), JwtModule.register({})],
     controllers: [AuthController],
     providers: [GoogleStrategy, AuthService, JwtAuthGuard, UserService, KakaoStrategy, NaverStrategy],
+    exports: [AuthService, JwtAuthGuard],
 })
 export class AuthModule {}

--- a/src/session-info/session-info.module.ts
+++ b/src/session-info/session-info.module.ts
@@ -16,5 +16,6 @@ import { RedGreenGame } from './entities/redgreen.game.entity';
     ],
     controllers: [SessionInfoController],
     providers: [SessionInfoService],
+    exports: [SessionInfoService],
 })
 export class SessionInfoModule {}

--- a/src/session/session.module.ts
+++ b/src/session/session.module.ts
@@ -1,16 +1,18 @@
 import { Module } from '@nestjs/common';
-import { AuthService } from 'src/auth/auth.service';
 import { JwtModule } from '@nestjs/jwt';
-import { UserService } from 'src/user/user.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/user/entities/user.entity';
 import { SessionGuard } from './session.guard';
-import { RedGreenGateway } from './game/redgreen.gateway';
-import { CatchGateway } from './game/catch.gateway';
-import { RedGreenService } from './game/redgreen.service';
+import { RedGreenGateway } from './redgreen.gateway';
+import { CatchGateway } from './catch.gateway';
+import { RedGreenService } from './redgreen.service';
+import { SessionInfoModule } from '../session-info/session-info.module';
+import { AuthModule } from '../auth/auth.module';
+import { UserModule } from '../user/user.module';
 
 @Module({
-    imports: [JwtModule.register({}), TypeOrmModule.forFeature([User])],
-    providers: [CatchGateway, RedGreenGateway, AuthService, UserService, RedGreenService, SessionGuard],
+    imports: [JwtModule.register({}), TypeOrmModule.forFeature([User]), SessionInfoModule, UserModule, AuthModule],
+    providers: [CatchGateway, RedGreenGateway, RedGreenService, SessionGuard],
+    exports: [SessionGuard],
 })
 export class SessionModule {}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -10,5 +10,6 @@ import { JwtModule } from '@nestjs/jwt';
     imports: [TypeOrmModule.forFeature([User]), JwtModule.register({})],
     controllers: [UserController],
     providers: [UserService, JwtAuthGuard],
+    exports: [UserService, JwtAuthGuard],
 })
 export class UserModule {}


### PR DESCRIPTION
이 풀 리퀘스트는 AuthModule, SessionInfoModule 및 UserModule에서 내보내기가 누락되는 문제를 해결합니다. 이제 AuthService, JwtAuthGuard 및 SessionGuard가 각 모듈에서 올바르게 내보내집니다. 이제 다른 모듈에서 이러한 서비스와 가드를 문제 없이 가져와서 사용할 수 있습니다.