### PR TITLE
hotfix(refresh-on-qr): QR 대기방에서 새로고침했을때 발생하는 문제

### DIFF
--- a/src/session/session.gateway.ts
+++ b/src/session/session.gateway.ts
@@ -111,7 +111,9 @@ export class SessionGateway implements OnGatewayConnection, OnGatewayDisconnect 
             return;
         }
 
-        this.uuidToclientEntity.get(uuId).clientSocket = null;
+        if (this.uuidToclientEntity.get(uuId).clientSocket === client) {
+          this.uuidToclientEntity.get(uuId).clientSocket = null;
+        }
         this.socketTouuid.delete(client.id);
         this.connectedSockets.delete(client.id);
     }
@@ -175,7 +177,8 @@ export class SessionGateway implements OnGatewayConnection, OnGatewayDisconnect 
                     ' 총 참가 인원: ' +
                     catchGame.current_user_num,
             );
-
+            
+            Logger.log('host: ' + host, 'custumDisconnect');
             host.emit('player_list_remove', {
                 player_cnt: catchGame.current_user_num,
                 nickname: enstity.nickname,
@@ -218,7 +221,10 @@ export class SessionGateway implements OnGatewayConnection, OnGatewayDisconnect 
             user_num: user_num,
             answer: answer,
         });
-        if (this.roomIdToHostId.has(hostInfo.id)) {
+        const hostuuid = this.roomIdToHostId.get(hostInfo.id);
+        if (hostuuid) {
+            const hostentity = this.uuidToclientEntity.get(hostuuid);
+            hostentity.clientSocket = client;
             this.destroyCatchGame(Number(hostInfo.id));
         }
 
@@ -421,6 +427,8 @@ export class SessionGateway implements OnGatewayConnection, OnGatewayDisconnect 
     private destroyCatchGame(room_id: number) {
         const hostuuid = this.roomIdToHostId.get(room_id);
         const host = this.uuidToclientEntity.get(hostuuid).clientSocket;
+
+        Logger.debug(room_id, `destroyCatchGame`);
 
         //게임 종료
         this.server.to(room_id.toString()).emit('end', {


### PR DESCRIPTION
호스트가 새로고침 버튼을 누르면 호스트의 uuId가 null이 되어 Exception
발생하는 문제

## 에러 로그

```
[Nest] 47175  - 11/29/2023, 3:03:58 AM   ERROR [WsExceptionsHandler] Cannot read properties of undefined (reading 'clientSocket')
TypeError: Cannot read properties of undefined (reading 'clientSocket')
    at SessionGateway.custumDisconnect (/home/ubuntu/recre-backend/src/session/session.gateway.ts:157:57)
    at SessionGateway.leaveGame (/home/ubuntu/recre-backend/src/session/session.gateway.ts:150:14)
    at /home/ubuntu/recre-backend/node_modules/@nestjs/websockets/context/ws-context-creator.js:43:33
    at processTicksAndRejections (node:internal/process/task_queues:95:5)
    at SessionGateway.<anonymous> (/home/ubuntu/recre-backend/node_modules/@nestjs/websockets/context/ws-proxy.js:12:32)
    at WebSocketsController.pickResult (/home/ubuntu/recre-backend/node_modules/@nestjs/websockets/web-sockets-controller.js:96:24)
```