### PR TITLE
game_finished payload : winners to player_info

### DIFF
--- a/src/session/redgreen.gateway.ts
+++ b/src/session/redgreen.gateway.ts
@@ -457,12 +457,7 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
     async finish(game: RedGreenGame) {
         const host_socket = this.uuidToSocket.get((await game.host).uuid);
         const players: RedGreenPlayer[] = (await game.players) as RedGreenPlayer[];
-        // const winners = [];
-        // for (const gamer of (await game.players) as RedGreenPlayer[]) {
-        //     if (gamer.state === 'FINISH') {
-        //         winners.push({ nickname: gamer.name, score: gamer.distance });
-        //     }
-        // }
+
         game.status = 'end';
         await this.sessionInfoService.redGreenGameSave(game);
         host_socket.emit('game_finished', { player_info: players });

--- a/src/session/redgreen.gateway.ts
+++ b/src/session/redgreen.gateway.ts
@@ -456,16 +456,16 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
 
     async finish(game: RedGreenGame) {
         const host_socket = this.uuidToSocket.get((await game.host).uuid);
-        const winners = [];
-        for (const gamer of (await game.players) as RedGreenPlayer[]) {
-            if (gamer.state === 'FINISH') {
-                winners.push({ nickname: gamer.name, score: gamer.distance });
-            }
-        }
+        const players: RedGreenPlayer[] = (await game.players) as RedGreenPlayer[];
+        // const winners = [];
+        // for (const gamer of (await game.players) as RedGreenPlayer[]) {
+        //     if (gamer.state === 'FINISH') {
+        //         winners.push({ nickname: gamer.name, score: gamer.distance });
+        //     }
+        // }
         game.status = 'end';
         await this.sessionInfoService.redGreenGameSave(game);
-        console.log('게임 종료 winners: ', winners);
-        host_socket.emit('game_finished', { winners });
+        host_socket.emit('game_finished', { player_info: players });
     }
 
     /**


### PR DESCRIPTION
- 게임 종료시 서버에서 우승자를 집계하여  호스트에 전달하던 기존 방식을 클라이언트 집계 방식으로 수정
- winners 배열을 전달하는 대신, 클라이언트에 player_status와 동일하게 모든 플레이어 정보를 담은 player_info를 전달.
- 클라이언트에서 player의 state와 endtime을 통해 순위 집계