### PR TITLE
feat(반자동 배포):  npm run build ⟶ EC2 자동배포

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "UNLICENSED",
   "scripts": {
     "precommit": "lint-staged",
-    "build": "nest build",
+    "build": "nest build && scp -r dist recre:/home/ubuntu/recre-backend",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "start": "nest start",
     "start:dev": "nest start --watch",


### PR DESCRIPTION
다만  `recre` 호스트가 `.ssh/config`에 정의되어있어야 합니다
