### PR TITLE
Add new features and fix bugs in RedGreenGame

### DIFF
--- a/src/session-info/session-info.service.ts
+++ b/src/session-info/session-info.service.ts
@@ -130,4 +130,15 @@ export class SessionInfoService {
             where: { uuid },
         });
     }
+
+    // 무궁화 꽃이 플레이어 정렬 조회
+    async redgreenGamePlayerSortedByMultipleConditions(room_id: number) {
+        return this.redGreenPlayerRepository.find({
+            where: { room: { room_id } },
+            order: {
+                distance: 'ASC',
+                endtime: 'DESC',
+            },
+        });
+    }
 }

--- a/src/session/redgreen.gateway.ts
+++ b/src/session/redgreen.gateway.ts
@@ -360,7 +360,7 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
         game.killer_mode = true;
         await this.sessionInfoService.redGreenGameSave(game);
 
-        this.server.to(game.room_id.toString()).emit('realtime_redgreen', { go: game.killer_mode });
+        this.server.to(game.room_id.toString()).emit('realtime_redgreen', { go: !game.killer_mode });
 
         client.emit('stop', { result: true });
     }
@@ -503,7 +503,7 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
             const players: RedGreenPlayer[] = (await game.players) as RedGreenPlayer[];
 
             const playersSorted = players.sort((a: RedGreenPlayer, b: RedGreenPlayer) => {
-                return a.distance - b.distance;
+                return b.distance - a.distance;
             });
 
             for (let i = 0; i < playersSorted.length; i++) {
@@ -560,7 +560,7 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
         await this.sessionInfoService.redGreenGameSave(game);
 
         const playersSorted = players.sort((a: RedGreenPlayer, b: RedGreenPlayer) => {
-            return a.distance - b.distance;
+            return b.distance - a.distance;
         });
 
         for (let i = 0; i < playersSorted.length; i++) {

--- a/src/session/redgreen.gateway.ts
+++ b/src/session/redgreen.gateway.ts
@@ -514,7 +514,7 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
                 try {
                     playerSocket.emit('realtime_my_rank', { rank: i + 1 });
                 } catch (error) {
-                    Logger.error(error);
+                    // Logger.error(error);
                 }
             }
         }
@@ -566,10 +566,7 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
             return b.distance - a.distance;
         });
 
-        for (let i = 0; i < playersSorted.length; i++) {
-            const playerSocket = this.uuidToSocket.get(playersSorted[i].uuid);
-            playerSocket.emit('game_finished', { rank: i + 1 });
-        }
+        this.server.to(game.room_id.toString()).emit('game_finished', { player_info: playersSorted });
 
         hostSocket.emit('game_finished', { player_info: playersSorted });
     }

--- a/src/session/redgreen.gateway.ts
+++ b/src/session/redgreen.gateway.ts
@@ -360,7 +360,7 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
         game.killer_mode = true;
         await this.sessionInfoService.redGreenGameSave(game);
 
-        this.server.to(game.room_id.toString()).emit('realtime_redgreen', { go: !game.killer_mode });
+        this.server.to(game.room_id.toString()).emit('realtime_redgreen', { go: false });
 
         client.emit('stop', { result: true });
     }
@@ -387,6 +387,9 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
             return { result: false, message: '게임이 시작되지 않았습니다.' };
         }
         game.killer_mode = false;
+
+        this.server.to(game.room_id.toString()).emit('realtime_redgreen', { go: true });
+
         await this.sessionInfoService.redGreenGameSave(game);
 
         client.emit('resume', { result: true });


### PR DESCRIPTION

이 풀 리퀘스트에는 RedGreenGame 모듈에 새로운 기능을 추가하고 버그를 수정하는 여러 커밋이 포함되어 있습니다. 변경 내용을 요약하면 다음과 같습니다:

redgreeGateway 모듈의 RedGreenGateway 클래스에 close_gate라는 새로운 엔드포인트를 추가했습니다.

redgreengame 모듈의 realtime_my_rank 이벤트에 주기적으로 플레이어 순위를 전송하기 위한 간격을 추가했습니다.

RedGreenGateway 클래스에서 파란 불 색상 변경 메시지를 플레이어들에게 전파하는 코드를 추가했습니다.

게임 종료 시 RedGreenGateway 클래스에서 플레이어 결과 데이터를 브로드캐스트하도록 코드를 수정했습니다.

이 변경 사항을 검토하고 본 브랜치에 병합해 주시기 바랍니다.