### PR TITLE
start_game시 서버가 startTime 전달 & game_finished시 서버가 ALIVE의 endTime 채우기

### DIFF
--- a/src/session-info/entities/redgreen.game.entity.ts
+++ b/src/session-info/entities/redgreen.game.entity.ts
@@ -20,4 +20,7 @@ export class RedGreenGame extends Room {
 
     @Column({ type: 'integer', nullable: false, default: 0 })
     current_alive_num: number;
+
+    @Column({ type: 'datetime', nullable: true, default: 0 })
+    start_time: Date;
 }

--- a/src/session-info/entities/redgreen.player.entity.ts
+++ b/src/session-info/entities/redgreen.player.entity.ts
@@ -13,8 +13,8 @@ export class RedGreenPlayer extends Player {
     state: string;
 
     /**
-     * 플레이어의 게임플레이가 종료된 시간 (사망, 완주 시간)
+     * 생존시간: 플레이어의 게임플레이가 종료된 시간 (사망, 완주 시간) - 게임 시작시간
      */
-    @Column({ type: 'datetime', nullable: true, default: 0 })
-    endtime: Date;
+    @Column({ type: 'integer', nullable: true, default: 0 })
+    elapsed_time: number;
 }

--- a/src/session/redgreen.gateway.ts
+++ b/src/session/redgreen.gateway.ts
@@ -294,11 +294,12 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
             return;
         }
         room.status = 'playing';
+        room.start_time = new Date();
         await this.sessionInfoService.redGreenGameSave(room);
         // 이제 호스트는 3,2,1 숫자를 세고 본 게임을 시작하게 된다.
-        const starttime = new Date();
-        this.server.to(room.room_id.toString()).emit('start_game', { result: true, starttime: starttime });
-        client.emit('start_game', { result: true, starttime: starttime });
+
+        this.server.to(room.room_id.toString()).emit('start_game', { result: true });
+        client.emit('start_game', { result: true });
     }
 
     @SubscribeMessage('im_ready')
@@ -414,21 +415,23 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
         }
 
         player.state = 'DEAD';
-        player.endtime = new Date();
+        const end_time = new Date();
+        player.elapsed_time = end_time.getTime() - game.start_time.getTime();
         game.current_alive_num -= 1;
         await this.sessionInfoService.redGreenGameSave(game);
         await this.sessionInfoService.redGreenGamePlayerSave(player);
+
         clientSocket.emit('youdie', {
             result: true,
             name: player.name,
             distance: player.distance,
-            endtime: player.endtime,
+            elapsed_time: player.elapsed_time,
         });
         hostSocket.emit('youdie', {
             result: true,
             name: player.name,
             distance: player.distance,
-            endtime: player.endtime,
+            elapsed_time: player.elapsed_time,
         });
     }
 
@@ -454,23 +457,25 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
         }
 
         player.state = 'FINISH';
-        player.endtime = new Date();
+        const end_time = new Date();
+        player.elapsed_time = end_time.getTime() - game.start_time.getTime();
         player.distance = game.length + game.win_num - game.current_win_num;
         game.current_win_num += 1;
         game.current_alive_num -= 1;
         await this.sessionInfoService.redGreenGameSave(game);
         await this.sessionInfoService.redGreenGamePlayerSave(player);
+
         clientsocket.emit('touchdown', {
             result: true,
             rank: game.current_win_num,
             name: player.name,
-            endtime: player.endtime,
+            elapsed_time: player.elapsed_time,
         });
         host_socket.emit('touchdown', {
             result: true,
             rank: game.current_win_num,
             name: player.name,
-            endtime: player.endtime,
+            elapsed_time: player.elapsed_time,
         });
     }
 
@@ -563,10 +568,11 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
         game.status = 'end';
         await this.sessionInfoService.redGreenGameSave(game);
 
-        const endtime = new Date();
+        const end_time = new Date();
+        const elapsed_time = end_time.getTime() - game.start_time.getTime();
         players.forEach((player) => {
             if (player.state == 'ALIVE') {
-                player.endtime = endtime;
+                player.elapsed_time = elapsed_time;
             }
         });
         const playersSorted = players.sort((a: RedGreenPlayer, b: RedGreenPlayer) => {

--- a/src/session/redgreen.gateway.ts
+++ b/src/session/redgreen.gateway.ts
@@ -296,8 +296,9 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
         room.status = 'playing';
         await this.sessionInfoService.redGreenGameSave(room);
         // 이제 호스트는 3,2,1 숫자를 세고 본 게임을 시작하게 된다.
-        this.server.to(room.room_id.toString()).emit('start_game', { result: true });
-        client.emit('start_game', { result: true });
+        const starttime = new Date();
+        this.server.to(room.room_id.toString()).emit('start_game', { result: true, starttime: starttime });
+        client.emit('start_game', { result: true, starttime: starttime });
     }
 
     @SubscribeMessage('im_ready')
@@ -562,6 +563,12 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
         game.status = 'end';
         await this.sessionInfoService.redGreenGameSave(game);
 
+        const endtime = new Date();
+        players.forEach((player) => {
+            if (player.state == 'ALIVE') {
+                player.endtime = endtime;
+            }
+        });
         const playersSorted = players.sort((a: RedGreenPlayer, b: RedGreenPlayer) => {
             return b.distance - a.distance;
         });

--- a/src/session/redgreen.gateway.ts
+++ b/src/session/redgreen.gateway.ts
@@ -563,18 +563,19 @@ export class RedGreenGateway implements OnGatewayConnection, OnGatewayDisconnect
 
     async finish(game: RedGreenGame) {
         const hostSocket = this.uuidToSocket.get((await game.host).uuid);
-        let players: RedGreenPlayer[] = (await game.players) as RedGreenPlayer[];
+        const players: RedGreenPlayer[] = (await game.players) as RedGreenPlayer[];
 
         game.status = 'end';
-        await this.sessionInfoService.redGreenGameSave(game);
 
         const end_time = new Date();
         const elapsed_time = end_time.getTime() - game.start_time.getTime();
         players.forEach((player) => {
-            if (player.state == 'ALIVE') {
+            if (player.state === 'ALIVE') {
                 player.elapsed_time = elapsed_time;
             }
         });
+        await this.sessionInfoService.redGreenGameSave(game);
+
         const playersSorted = players.sort((a: RedGreenPlayer, b: RedGreenPlayer) => {
             return b.distance - a.distance;
         });


### PR DESCRIPTION
`start_game`시 start time을 일괄적으로 전달 : server→client
`game_finished`시 ALIVE 상태의 플레이어들의 end time을 종료시간으로 채운뒤 player_info를 브로드캐스트


close #102 