### PR TITLE
session-info.service의 endtime 주석처리

### DIFF
--- a/src/session-info/session-info.service.ts
+++ b/src/session-info/session-info.service.ts
@@ -137,7 +137,7 @@ export class SessionInfoService {
             where: { room: { room_id } },
             order: {
                 distance: 'ASC',
-                endtime: 'DESC',
+                // endtime: 'DESC',
             },
         });
     }


### PR DESCRIPTION
elapsed-time 도입으로 인해 session-info.service의 endtime 주석처리