### PR TITLE
Use SOCKET_PORT from environment variables in WebSocketGateway decorator

### DIFF
--- a/src/session/catch.gateway.ts
+++ b/src/session/catch.gateway.ts
@@ -17,8 +17,11 @@ import { Host } from 'src/session-info/entities/host.entity';
 import { CatchGame } from 'src/session-info/entities/catch.game.entity';
 import { SocketExtension } from './socket.extension';
 import * as AsyncLock from 'async-lock';
+import * as dotenv from 'dotenv';
 
-@WebSocketGateway({
+dotenv.config();
+
+@WebSocketGateway(+process.env.SOCKET_PORT, {
     namespace: 'catch', /// TODO - namespace는 나중에 정의할 것
     transports: ['websocket'],
     pingInterval: 3000,

--- a/src/session/redgreen.gateway.ts
+++ b/src/session/redgreen.gateway.ts
@@ -14,8 +14,11 @@ import { RedGreenPlayer } from 'src/session-info/entities/redgreen.player.entity
 import { Host } from 'src/session-info/entities/host.entity';
 import { RedGreenGame } from 'src/session-info/entities/redgreen.game.entity';
 import * as AsyncLock from 'async-lock';
+import * as dotenv from 'dotenv';
 
-@WebSocketGateway({
+dotenv.config();
+
+@WebSocketGateway(+process.env.SOCKET_PORT, {
     namespace: 'redgreen',
     transports: ['websocket'],
     pingInterval: 3000,


### PR DESCRIPTION
SOCKET_PORT 환경 변수를 사용하도록 WebSocketGateway를 구성하여 환경에 따라 동적 포트 할당을 허용합니다.

---

**변경사항**

.env 파일에 `SOCKET_PORT`가 추가되었습니다. Notion, README.md에 추가가 되어야 합니다.